### PR TITLE
change timeout in generated nodeconfig.js from 30000 to 30

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -165,7 +165,7 @@ def create_node_config(avd_name: str, browser_name: str, appium_host: str, appiu
         ],
         'configuration': {
             'cleanUpCycle': 2000,
-            'timeout': 30000,
+            'timeout': 30,
             'proxy': 'org.openqa.grid.selenium.proxy.DefaultRemoteProxy',
             'url': 'http://{host}:{port}/wd/hub'.format(host=appium_host, port=appium_port),
             'host': appium_host,


### PR DESCRIPTION
### Purpose of changes
In the 3.x version of selenium hub the timeout is now given in seconds
See https://github.com/SeleniumHQ/selenium/issues/5218 

### Types of changes
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
- [x] emulated device
- [] real device
