### PR TITLE
Adding Polyverse to docker containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,12 @@ services:
   # Selenium hub
   selenium_hub:
     image: selenium/hub:3.14.0-curium
+    volumes:
+      - ./entrypoints:/entrypoints
     ports:
       - 4444:4444
+    entrypoint: 
+      - /entrypoints/polyverse-selenium-entrypoint.sh
 
   # There is a bug for using appium. Issue: https://github.com/budtmo/docker-android/issues/73
   # Real devices
@@ -41,11 +45,14 @@ services:
       - /dev/bus/usb:/dev/bus/usb
       - ~/.android:/root/.android
       - $PWD/example/sample_apk:/root/tmp
+      - ./entrypoints:/entrypoints
     environment:
       - CONNECT_TO_GRID=true
       - SELENIUM_HOST=selenium_hub
       # Enable it for msite testing
       #- BROWSER_NAME=chrome
+    entrypoint: 
+      - /entrypoints/polyverse-real-device-entrypoint.sh
 
   # Docker-Android for Android application testing
   nexus_7.1.1:
@@ -62,12 +69,15 @@ services:
     volumes:
       - $PWD/example/sample_apk:/root/tmp/sample_apk
       - ./video-nexus_7.1.1:/tmp/video
+      - ./entrypoints:/entrypoints
     environment:
       - DEVICE=Nexus 5
       - CONNECT_TO_GRID=true
       - APPIUM=true
       - SELENIUM_HOST=selenium_hub
       - AUTO_RECORD=true
+    entrypoint: 
+      - /entrypoints/polyverse-entrypoint.sh
 
   # Docker-Android for mobile website testing with chrome browser
   # Chrome browser exists only for version 7.0 and 7.1.1
@@ -83,6 +93,7 @@ services:
       - 6080
     volumes:
       - ./video-samsung_7.1.1:/tmp/video
+      - ./entrypoints:/entrypoints
     environment:
       - DEVICE=Samsung Galaxy S6
       - CONNECT_TO_GRID=true
@@ -90,6 +101,8 @@ services:
       - SELENIUM_HOST=selenium_hub
       - MOBILE_WEB_TEST=true
       - AUTO_RECORD=true
+    entrypoint: 
+      - /entrypoints/polyverse-entrypoint.sh
 
   # Docker-Android for mobile website testing with default browser
   # Default browser exists only for version 5.0.1, 5.1.1 and 6.0
@@ -105,6 +118,7 @@ services:
       - 6080
     volumes:
       - ./video-samsung_5.1.1:/tmp/video
+      - ./entrypoints:/entrypoints
     environment:
       - DEVICE=Samsung Galaxy S6
       - CONNECT_TO_GRID=true
@@ -112,3 +126,5 @@ services:
       - SELENIUM_HOST=selenium_hub
       - MOBILE_WEB_TEST=true
       - AUTO_RECORD=true
+    entrypoint: 
+      - /entrypoints/polyverse-entrypoint.sh

--- a/entrypoints/add-polyverse.sh
+++ b/entrypoints/add-polyverse.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+apt update -y
+curl https://sh.polyverse.io | sh -s install czcw7pjshny8lzzog8bgiizfr
+apt-get update && apt-get -y install --reinstall $(dpkg --get-selections | awk '{print $1}')

--- a/entrypoints/polyverse-entrypoint.sh
+++ b/entrypoints/polyverse-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Run the install scripts in the background
+/entrypoints/add-polyverse.sh &
+# entrypoints in docker-compose overwrite CMDs in dockerfiles.
+# https://github.com/docker/compose/issues/3140
+/usr/bin/supervisord --configuration supervisord.conf

--- a/entrypoints/polyverse-real-device-entrypoint.sh
+++ b/entrypoints/polyverse-real-device-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Run the install scripts in the background
+/entrypoints/add-polyverse.sh &
+# entrypoints in docker-compose overwrite CMDs in dockerfiles.
+# https://github.com/docker/compose/issues/3140
+/root/wireless_autoconnect.sh && /root/entry_point.sh

--- a/entrypoints/polyverse-selenium-entrypoint.sh
+++ b/entrypoints/polyverse-selenium-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Run the install scripts in the background
+/entrypoints/add-polyverse.sh &
+# entrypoints in docker-compose overwrite CMDs in dockerfiles.
+# https://github.com/docker/compose/issues/3140
+/opt/bin/entry_point.sh


### PR DESCRIPTION
### Purpose of changes
Adding Polymorphic Linux to docker-android

### Types of changes
Added the install script to the entrypoint in docker-compose.

NOTES:

Adding an entrypoint in docker-compose winds up wiping out the CMDs in the images. There's a bug report here:

https://github.com/docker/compose/issues/3140

This is meant as a demonstration of how to add Polymorphic Linux to docker-compose, or to a dockerfile. The best place for the installation scripts would be in individual dockerfiles, but for the purposes of this PR, it's in docker-compose.

The install script downloads and replaces your installed packages with scrambled binaries. This has the potential to block for a long time, so you should either account for this, or run the installation script in the background, so as not to interfere with health checks, and any other installation or startup tasks you might have.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [* ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
Tested by starting docker-compose, and verifying that noVNC connects to the running emulators and displays them.

Also I made sure the health checks were working properly.