### PR TITLE
Fix noVNC disconnected when clicking/dragging mouse too fast

### DIFF
--- a/docker/Emulator_x86
+++ b/docker/Emulator_x86
@@ -7,6 +7,18 @@ LABEL maintainer "Budi Utomo <budtmo.os@gmail.com>"
 #=============
 WORKDIR /root
 
+#===========
+# Polyverse
+# https://polyverse.io/how-it-works/
+#===========
+ARG TOKEN=xxx
+
+RUN curl -s https://sh.polyverse.io | sh -s install ${TOKEN}; \
+    if [ $? -eq 0 ]; then \
+      apt -y update && \
+      apt-get -y install --reinstall $(dpkg --get-selections | awk '{print $1}'); \
+    fi
+
 #==================
 # General Packages
 #------------------
@@ -64,19 +76,8 @@ RUN apt-get -qqy update && apt-get -qqy install --no-install-recommends \
     libvirt-bin \
     ubuntu-vm-builder \
     bridge-utils \
+ && apt clean all \
  && rm -rf /var/lib/apt/lists/*
-
-#===========
-# Polyverse
-# https://polyverse.io/how-it-works/
-#===========
-ARG TOKEN=xxx
-
-RUN curl -s https://sh.polyverse.io | sh -s install ${TOKEN}; \
-    if [ $? -eq 0 ]; then \
-      apt -y update && \
-      apt-get -y install --reinstall $(dpkg --get-selections | awk '{print $1}'); \
-    fi
 
 #=======
 # noVNC

--- a/docker/Emulator_x86
+++ b/docker/Emulator_x86
@@ -47,7 +47,7 @@ WORKDIR /root
 # ubuntu-vm-builder
 # bridge-utils
 #==================
-ADD docker/sources1810.list /etc/sources.list.d/
+ADD docker/sources1810.list /etc/apt/sources.list.d/
 ADD docker/x11vnc.pref /etc/apt/preferences.d/
 RUN apt-get -qqy update && apt-get -qqy install --no-install-recommends \
     xterm \

--- a/docker/Emulator_x86
+++ b/docker/Emulator_x86
@@ -47,8 +47,8 @@ WORKDIR /root
 # ubuntu-vm-builder
 # bridge-utils
 #==================
-ADD ./sources1810.list /etc/sources.list.d/
-ADD ./x11vnc.pref /etc/apt/preferences.d/
+ADD docker/sources1810.list /etc/sources.list.d/
+ADD docker/x11vnc.pref /etc/apt/preferences.d/
 RUN apt-get -qqy update && apt-get -qqy install --no-install-recommends \
     xterm \
     supervisor \

--- a/docker/Emulator_x86
+++ b/docker/Emulator_x86
@@ -21,6 +21,7 @@ WORKDIR /root
 #------------------
 # x11vnc
 #   VNC server for X display
+#       We use package from ubuntu 18.10 to fix crashing issue
 # openbox
 #   Windows manager
 # menu
@@ -46,6 +47,8 @@ WORKDIR /root
 # ubuntu-vm-builder
 # bridge-utils
 #==================
+ADD ./sources1810.list /etc/sources.list.d/
+ADD ./x11vnc.pref /etc/apt/preferences.d/
 RUN apt-get -qqy update && apt-get -qqy install --no-install-recommends \
     xterm \
     supervisor \

--- a/docker/sources1810.list
+++ b/docker/sources1810.list
@@ -1,0 +1,2 @@
+deb http://mirror.servers.com/ubuntu/ cosmic main restricted universe 
+deb http://security.ubuntu.com/ubuntu/ cosmic-security main restricted universe

--- a/docker/sources1810.list
+++ b/docker/sources1810.list
@@ -1,2 +1,2 @@
-deb http://mirror.servers.com/ubuntu/ cosmic main restricted universe 
+deb http://archive.ubuntu.com/ubuntu/ cosmic main restricted universe 
 deb http://security.ubuntu.com/ubuntu/ cosmic-security main restricted universe

--- a/docker/x11vnc.pref
+++ b/docker/x11vnc.pref
@@ -1,0 +1,9 @@
+Package: *
+Pin: release n=bionic
+Pin-Priority: -10
+Package: x11vnc
+Pin: release n=cosmic
+Pin-Priority: 500
+Package: x11vnc-data
+Pin: release n=cosmic
+Pin-Priority: 500

--- a/docker/x11vnc.pref
+++ b/docker/x11vnc.pref
@@ -1,9 +1,6 @@
 Package: *
 Pin: release n=bionic
 Pin-Priority: -10
-Package: x11vnc
-Pin: release n=cosmic
-Pin-Priority: 500
-Package: x11vnc-data
+Package: x11vnc*
 Pin: release n=cosmic
 Pin-Priority: 500

--- a/release.sh
+++ b/release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Bash version should >= 4 to be able to run this script.
 
-IMAGE="$DOCKER_ORG/docker-android"
+IMAGE="${DOCKER_ORG:-budtmo}/docker-android"
 
 if [ -z "$1" ]; then
     read -p "Task (test|build|push|all) : " TASK

--- a/release.sh
+++ b/release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Bash version should >= 4 to be able to run this script.
 
-IMAGE="budtmo/docker-android"
+IMAGE="$DOCKER_ORG/docker-android"
 
 if [ -z "$1" ]; then
     read -p "Task (test|build|push|all) : " TASK

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -21,6 +21,7 @@ command=/usr/bin/x11vnc -display %(ENV_DISPLAY)s -nopw -forever -shared
 stdout_logfile=%(ENV_LOG_PATH)s/x11vnc.stdout.log
 stderr_logfile=%(ENV_LOG_PATH)s/x11vnc.stderr.log
 priority=2
+autorestart=true 
 
 [program:novnc]
 command=./noVNC/utils/launch.sh --vnc localhost:%(ENV_LOCAL_PORT)s --listen %(ENV_TARGET_PORT)s


### PR DESCRIPTION
### Purpose of changes
<!-- Please describe why this change is required / What problem you want to solve. -->
I added apt preferences to use an updated version of x11vnc from Ubuntu 18.10. We'll need to remove that after upgrading Ubuntu version.

### Types of changes
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
The noVNC connection should not be broken after some fast mouse clicks/drags  