### PR TITLE
Single virtual desktop

### DIFF
--- a/docker/Emulator_x86
+++ b/docker/Emulator_x86
@@ -158,6 +158,13 @@ ENV DISPLAY=:0 \
     VIDEO_PATH=/tmp/video \
     LOG_PATH=/var/log/supervisor
 
+#================================================
+# openbox configuration
+# Update the openbox configuration files to:
+#   + Use a single virtual desktop to prevent accidentally switching 
+#================================================
+RUN sed -i "s/<number>4<\/number>/<number>1<\/number>/g" /etc/xdg/openbox/rc.xml
+
 #===============
 # Expose Ports
 #---------------


### PR DESCRIPTION
### Purpose of changes
<!-- Please describe why this change is required / What problem you want to solve. -->
Let openbox uses one virtual desktop to prevent loosing the emulator view because of scrolling mouse (which causes change virtual desktop).

### Types of changes
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
You should have the only one desktop and cannot switch via scrolling mouse