### PR TITLE
Makes re-using AVDs work for non-Samsung devices

### DIFF
--- a/README_CUSTOM_CONFIG.md
+++ b/README_CUSTOM_CONFIG.md
@@ -51,7 +51,7 @@ If you want to backup/reuse the avds created with furture upgrades or for replic
 - -v local_backup/android_emulator:/root/android_emulator
 
 ```bash
-docker run --privileged -d -p 6080:6080 -p 4723:4723 -p 5554:5554 -p 5555:5555 -v local_backup/.android:/root/.android -v local_backup/android_emulator:local_backup/android_emulator -e DEVICE="Nexus 5" --name android-container budtmo/docker-android-x86-8.1
+docker run --privileged -d -p 6080:6080 -p 4723:4723 -p 5554:5554 -p 5555:5555 -v local_backup/.android:/root/.android -v local_backup/android_emulator:/root/android_emulator -e DEVICE="Nexus 5" --name android-container budtmo/docker-android-x86-8.1
 ```
 
 For the first run, this will create a new avd and all the changes will be accessible in the `local_backup` directory. Now for all future runs, it will reuse the avds. Even this should work with new releases of `docker-android`

--- a/src/tests/unit/test_app.py
+++ b/src/tests/unit/test_app.py
@@ -96,7 +96,7 @@ class TestApp(TestCase):
     @mock.patch('builtins.open')
     @mock.patch('subprocess.Popen')
     @mock.patch('os.path.exists', mock.MagicMock(return_value=False))
-    def test_run_first_run(self, mocked_open, mocked_subprocess):
+    def test_it_prepares_avd_on_first_run(self, mocked_open, mocked_subprocess):
         with mock.patch('src.app.prepare_avd') as mocked_prepare_avd:
             app.run()
             self.assertFalse(app.is_initialized('Nexus 5'))
@@ -105,8 +105,17 @@ class TestApp(TestCase):
     @mock.patch('subprocess.Popen')
     @mock.patch('os.path.exists', mock.MagicMock(return_value=True))
     @mock.patch('builtins.open', mock_open(read_data="\nhw.device.name=Nexus 5\n"))
-    def test_run_next_run(self, mocked_subprocess):
+    def test_it_doesnt_prepare_avd_if_config_exists(self, mocked_subprocess):
         with mock.patch('src.app.prepare_avd') as mocked_prepare_avd:
             app.run()
             self.assertTrue(app.is_initialized('Nexus 5'))
             self.assertFalse(mocked_prepare_avd.called)
+
+    @mock.patch('subprocess.Popen')
+    @mock.patch('os.path.exists', mock.MagicMock(return_value=True))
+    @mock.patch('builtins.open', mock_open(read_data="\nhw.device.name=Samsung S7\n"))
+    def test_it_prepares_avd_if_config_is_for_another_device(self, mocked_subprocess):
+        with mock.patch('src.app.prepare_avd') as mocked_prepare_avd:
+            app.run()
+            self.assertFalse(app.is_initialized('Nexus 5'))
+            self.assertTrue(mocked_prepare_avd.called)

--- a/src/tests/unit/test_app.py
+++ b/src/tests/unit/test_app.py
@@ -7,6 +7,13 @@ import mock
 from src import app
 
 
+# https://bugs.python.org/issue21258
+def mock_open(*args, **kargs):
+    f_open = mock.mock_open(*args, **kargs)
+    f_open.return_value.__iter__ = lambda self : iter(self.readline, '')
+    return f_open
+
+
 class TestApp(TestCase):
     """Unit test class to test other methods in the app."""
 
@@ -60,7 +67,6 @@ class TestApp(TestCase):
             os.environ['APPIUM'] = str(True)
             app.run()
             self.assertTrue(mocked_avd.called)
-            self.assertTrue(mocked_open.called)
             self.assertTrue(mocked_subprocess.called)
             self.assertTrue(mocked_appium.called)
 
@@ -73,7 +79,6 @@ class TestApp(TestCase):
             os.environ['RELAXED_SECURITY'] = str(True)
             app.run()
             self.assertTrue(mocked_avd.called)
-            self.assertTrue(mocked_open.called)
             self.assertTrue(mocked_subprocess.called)
             self.assertTrue(mocked_appium.called)
 
@@ -85,7 +90,6 @@ class TestApp(TestCase):
             os.environ['APPIUM'] = str(False)
             app.run()
             self.assertTrue(mocked_avd.called)
-            self.assertTrue(mocked_open.called)
             self.assertTrue(mocked_subprocess.called)
             self.assertFalse(mocked_appium.called)
 
@@ -95,14 +99,14 @@ class TestApp(TestCase):
     def test_run_first_run(self, mocked_open, mocked_subprocess):
         with mock.patch('src.app.prepare_avd') as mocked_prepare_avd:
             app.run()
-            self.assertFalse(app.is_initialized())
+            self.assertFalse(app.is_initialized('Nexus 5'))
             self.assertTrue(mocked_prepare_avd.called)
 
-    @mock.patch('builtins.open')
     @mock.patch('subprocess.Popen')
     @mock.patch('os.path.exists', mock.MagicMock(return_value=True))
-    def test_run_next_run(self, mocked_open, mocked_subprocess):
+    @mock.patch('builtins.open', mock_open(read_data="\nhw.device.name=Nexus 5\n"))
+    def test_run_next_run(self, mocked_subprocess):
         with mock.patch('src.app.prepare_avd') as mocked_prepare_avd:
             app.run()
-            self.assertTrue(app.is_initialized())
+            self.assertTrue(app.is_initialized('Nexus 5'))
             self.assertFalse(mocked_prepare_avd.called)

--- a/src/tests/unit/test_avd.py
+++ b/src/tests/unit/test_avd.py
@@ -18,7 +18,7 @@ class TestAvd(TestCase):
     def test_nexus_avd_as_default(self, mocked_suprocess, mocked_open):
         self.assertFalse(mocked_suprocess.called)
         self.assertFalse(mocked_open.called)
-        app.prepare_avd('Nexus 5', self.avd_name)
+        app.prepare_avd('Nexus 5', self.avd_name, '550m')
         self.assertTrue(mocked_suprocess.called)
         self.assertTrue(mocked_open.called)
 
@@ -28,7 +28,7 @@ class TestAvd(TestCase):
         self.assertFalse(mocked_sys_link.called)
         self.assertFalse(mocked_suprocess.called)
         self.assertFalse(mocked_open.called)
-        app.prepare_avd('Samsung Galaxy S6', self.avd_name)
+        app.prepare_avd('Samsung Galaxy S6', self.avd_name, '550m')
         self.assertTrue(mocked_sys_link.called)
         self.assertTrue(mocked_suprocess.called)
         self.assertTrue(mocked_open.called)


### PR DESCRIPTION
### Purpose of changes

Resolves: #170 

Previously, the decision about whether or not a device has been previously initialized relied on the existence of `/root/.android/devices.xml`, which is [only created for Samsung AVDs](https://github.com/budtmo/docker-android/blob/master/src/app.py#L84). This PR decouples this decision from the existence of custom hardware profiles, by instead checking whether or not `/root/android_emulator/config.ini` exists _and_ references the current device (specified at run time via `-e DEVICE="__device_name__"`).

This PR should only impact users running the docker image with mounted volumes for `/root/android_emulator` and `/root/.android` for AVD persistence, as per [docs](https://github.com/budtmo/docker-android/blob/master/README_CUSTOM_CONFIG.md#back--restore).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?

**Step 0**. Build the new image
`echo "debug" | ./release.sh build 9.0`

**Step 1**. Run with empty volumes (`~jenkins/android_local_backup/` is empty)
`docker run --rm --privileged -d -p 6080:6080 -p 4723:4723 -p 5554:5554 -p 5555:5555 -v ~jenkins/android_local_backup/.android:/root/.android -v ~jenkins/android_local_backup/android_emulator:/root/android_emulator -e DEVICE="Nexus 5" -e EMULATOR_ARGS="-no-boot-anim" --name android-container budtmo/docker-android-x86-9.0:debug`
Observed behavior: emulator cold-boots. 

**Step 2**. Close the emulator, stop the container, re-run with same volumes, as they were populated in the previous run
`docker run --rm --privileged -d -p 6080:6080 -p 4723:4723 -p 5554:5554 -p 5555:5555 -v ~jenkins/android_local_backup/.android:/root/.android -v ~jenkins/android_local_backup/android_emulator:/root/android_emulator -e DEVICE="Nexus 5" -e EMULATOR_ARGS="-no-boot-anim" --name android-container budtmo/docker-android-x86-9.0:debug`
Observed behavior: emulator quick-boots from the saved snapshot.
 
**Step 3**. Re-run with same volumes, but with different device
`docker run --rm --privileged -d -p 6080:6080 -p 4723:4723 -p 5554:5554 -p 5555:5555 -v ~jenkins/android_local_backup/.android:/root/.android -v ~jenkins/android_local_backup/android_emulator:/root/android_emulator -e DEVICE="Samsung Galaxy S6" -e EMULATOR_ARGS="-no-boot-anim" --name android-container budtmo/docker-android-x86-9.0:debug`
Observed behavior: data is wiped, emulator cold-boots. Expected, since the existing config references a different device.

**Step 4**. Close the emulator, re-run container with same device as step 3
Step 3. Re-run with same volumes, but with different device
`docker run --rm --privileged -d -p 6080:6080 -p 4723:4723 -p 5554:5554 -p 5555:5555 -v ~jenkins/android_local_backup/.android:/root/.android -v ~jenkins/android_local_backup/android_emulator:/root/android_emulator -e DEVICE="Samsung Galaxy S6" -e EMULATOR_ARGS="-no-boot-anim" --name android-container budtmo/docker-android-x86-9.0:debug`
Observed behavior: emulator quick-boots from the previously saved snapshot.
