### PR TITLE
Add subnet_id parameter

### DIFF
--- a/README_GENYMOTION.md
+++ b/README_GENYMOTION.md
@@ -24,4 +24,18 @@ You can easily scale your Appium tests on Genymotion Android virtual devices in 
 	docker run -it --rm -p 4723:4723 -v $PWD/genymotion/example/sample_devices:/root/tmp -v ~/.aws:/root/.aws -e TYPE=aws budtmo/docker-android-genymotion
 	```
 
+	Existing security group and subnet can be used:
+
+	```json
+	[
+		{
+			"region": "us-west-2",
+			"instance": "t2.small",
+			"AMI": "ami-0673cbd39ef84d97c",
+			"SG": "sg-000aaa",
+			"subnet_id": "subnet-000aaa"
+		}
+	]
+	``` 
+
 You can also use [this docker-compose file](genymotion/example/geny.yml). 

--- a/src/appium.sh
+++ b/src/appium.sh
@@ -59,12 +59,17 @@ function prepare_geny_aws() {
 		instance=$(get_value '.instance')
 		ami=$(get_value '.AMI')
 		sg=$(get_value '.SG')
+		subnet_id=$(get_value '.subnet_id')
+		if [[ $subnet_id == null ]]; then
+			subnet_id=""
+		fi
 
 		echo $region
 		echo $android_version
 		echo $instance
 		echo $ami
 		echo $sg
+		echo $subnet_id
 
 	    #TODO: remove this dirty hack
 		if [[ $android_version == null ]]; then
@@ -183,6 +188,11 @@ variable "instance_type_$index" {
 	default = "$instance"
 }
 
+variable "subnet_id_$index" {
+	type	= "string"
+	default = "$subnet_id"
+}
+
 provider "aws" {
 	alias = "provider_$index"
 	region  = "\${var.aws_region_$index}"
@@ -214,6 +224,7 @@ resource "aws_instance" "geny_aws_$index" {
 	provider      = "aws.provider_$index"
 	ami="\${data.aws_ami.geny_aws_$index.id}"
 	instance_type = "\${var.instance_type_$index}"
+	subnet_id = "\${var.subnet_id_$index}"
 	vpc_security_group_ids=["\${aws_security_group.geny_sg_$index.name}"]
 	key_name      = "\${aws_key_pair.geny_key_$index.key_name}"
 	tags {


### PR DESCRIPTION
### Purpose of changes
When aws zone doesn't have default vpc, terraform tries to create resources in ec2-classic. Setting subnet_id tells terraform to create resources in ec2-vpc

### Types of changes
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
tested on k8s on ec2+genimotion