### PR TITLE
add optional option for device name in json and use random name instead

### DIFF
--- a/src/appium.sh
+++ b/src/appium.sh
@@ -23,8 +23,15 @@ function prepare_geny_cloud() {
 	    device=$(get_value '.device')
 	    port=$(get_value '.port')
 
-	    echo "Starting \"$device\" with template name \"$template\"..."
-	    instance_uuid=$(gmsaas instances start "${template}" "${device}")
+		if [[ $device != null ]]; then
+			echo "Starting \"$device\" with template name \"$template\"..."
+			instance_uuid=$(gmsaas instances start "${template}" "${device}")
+		else
+			echo "Starting Device with Random name..."
+			random_device_name=$(python3  -c 'import uuid; print(str(uuid.uuid4()).upper())')
+			instance_uuid=$(gmsaas instances start "${template}" "${random_device_name}")
+		fi
+
 	    echo "Instance-ID: \"$instance_uuid\""
 	    created_instances+=("${instance_uuid}")
 


### PR DESCRIPTION
### Purpose of changes
when starting geny cloud SaaS it's mandatory to provide device name in devices.json file, but i think it should be optional and we can provide random name instead, because currently it'll break if i scale my container because of geny cloud can't create instances with same name

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
tested with device name provided and not provided and verified devices is up in geny cloud when scale it to multiple device with device name is not provided



### Note
from this perspective, i think  when user only need one template for geny SaaS, we need to make devices.json optional, and replace it by env var like "GENY_TEMPLATE"