### PR TITLE
Add data partition size variable documentation

### DIFF
--- a/README_CUSTOM_CONFIG.md
+++ b/README_CUSTOM_CONFIG.md
@@ -16,6 +16,15 @@ You can change the language setting of Android Emulator on the fly by passing fo
 - LANGUAGE="\<language>"
 - COUNTRY="\<country>"
 
+Data partition size
+-------------------
+
+The size of the data partition can be set by passing the following environment variable:
+
+- DATAPARTITION="\<size>"
+
+The value can be specified in the same format that is used by the emulator config file (`disk.dataPartition.size`), e.g. `800m`.
+
 Camera
 ------
 


### PR DESCRIPTION
### Purpose of changes
Documenting the `DATAPARTITION` environment variable

### Types of changes
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documenting an existing feature

### How has this been tested?
Found it in #193 and tested by running `adb shell df`
