### PR TITLE
Add optional env to set avd name

### DIFF
--- a/README_CUSTOM_CONFIG.md
+++ b/README_CUSTOM_CONFIG.md
@@ -32,6 +32,14 @@ Passing following environment variable to be able to connect laptop / pc camera 
 
 - EMULATOR_ARGS="-camera-back webcam0"
 
+Custom Avd name Arguments
+-------------------------
+
+Passing following environment variable to set a custom avd name
+
+- AVD_NAME="customName"
+
+
 Custom Emulator Arguments
 -------------------------
 

--- a/src/app.py
+++ b/src/app.py
@@ -206,7 +206,7 @@ def run():
     custom_args=os.getenv('EMULATOR_ARGS', '')
     logger.info('Custom Args: {custom_args}'.format(custom_args=custom_args))
 
-    avd_name = '{device}_{version}'.format(device=device.replace(' ', '_').lower(), version=ANDROID_VERSION)
+    avd_name = os.getenv('AVD_NAME', '{device}_{version}'.format(device=device.replace(' ', '_').lower(), version=ANDROID_VERSION))
     logger.info('AVD name: {avd}'.format(avd=avd_name))
     is_first_run = not is_initialized(device)
 


### PR DESCRIPTION
### Purpose of changes
To be able to target a unique emulator in a pool of emulators from the selenium grid, I need to set the avd name of an emulator.

### Types of changes
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
I rebuilt the image locally and tried to retrieve in the container the avd name with and without the env variable AVD_NAME set. And also I checked inside the container if the ~/src/nodeconfig.json file was updated accordingly.
