### PR TITLE
Add selenium session timeout configuration via environment variable

### DIFF
--- a/README_APPIUM_AND_SELENIUM.md
+++ b/README_APPIUM_AND_SELENIUM.md
@@ -24,6 +24,7 @@ It is also possible to connect appium server that run inside docker-android with
 - APPIUM_PORT=\<port\_number>
 - SELENIUM_HOST="\<host\_ip\_address>"
 - SELENIUM_PORT=\<port\_number>
+- SELENIUM_TIMEOUT=\<timeout\_in\_seconds>
 
 To run tests for mobile browser, following parameter can be passed:
 

--- a/src/app.py
+++ b/src/app.py
@@ -148,8 +148,10 @@ def appium_run(avd_name: str):
             appium_port = int(os.getenv('APPIUM_PORT', 4723))
             selenium_host = os.getenv('SELENIUM_HOST', '172.17.0.1')
             selenium_port = int(os.getenv('SELENIUM_PORT', 4444))
+            selenium_timeout = int(os.getenv('SELENIUM_TIMEOUT', 30))
             browser_name = default_web_browser if mobile_web_test else 'android'
-            create_node_config(avd_name, browser_name, appium_host, appium_port, selenium_host, selenium_port)
+            create_node_config(avd_name, browser_name, appium_host, appium_port, selenium_host, selenium_port,
+                               selenium_timeout)
             cmd += ' --nodeconfig {file}'.format(file=CONFIG_FILE)
         except ValueError as v_err:
             logger.error(v_err)
@@ -158,7 +160,7 @@ def appium_run(avd_name: str):
 
 
 def create_node_config(avd_name: str, browser_name: str, appium_host: str, appium_port: int, selenium_host: str,
-                       selenium_port: int):
+                       selenium_port: int, selenium_timeout: int):
     """
     Create custom node config file in json format to be able to connect with selenium server.
 
@@ -167,6 +169,7 @@ def create_node_config(avd_name: str, browser_name: str, appium_host: str, appiu
     :param appium_port: Port number where where appium server is running
     :param selenium_host: Host where selenium server is running
     :param selenium_port: Port number where selenium server is running
+    :param selenium_timeout: Selenium session timeout in seconds
     """
     config = {
         'capabilities': [
@@ -181,7 +184,7 @@ def create_node_config(avd_name: str, browser_name: str, appium_host: str, appiu
         ],
         'configuration': {
             'cleanUpCycle': 2000,
-            'timeout': 30,
+            'timeout': selenium_timeout,
             'proxy': 'org.openqa.grid.selenium.proxy.DefaultRemoteProxy',
             'url': 'http://{host}:{port}/wd/hub'.format(host=appium_host, port=appium_port),
             'host': appium_host,

--- a/src/tests/unit/test_appium.py
+++ b/src/tests/unit/test_appium.py
@@ -58,7 +58,7 @@ class TestAppium(TestCase):
     def test_config_creation(self):
         from src import CONFIG_FILE
         self.assertFalse(os.path.exists(CONFIG_FILE))
-        app.create_node_config('test', 'android', '127.0.0.1', 4723, '127.0.0.1', 4444)
+        app.create_node_config('test', 'android', '127.0.0.1', 4723, '127.0.0.1', 4444, 30)
         self.assertTrue(os.path.exists(CONFIG_FILE))
         os.remove(CONFIG_FILE)
 


### PR DESCRIPTION
### Purpose of changes
Add environment variable to configure selenium session timeout.

### Types of changes
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
I built the image locally and run it with the default timeout value and with a custom timeout value. Also, I checked inside the container that nodeconfig.json file was composed accordingly.
