### PR TITLE
Workaround for "Running as root without --no-sandbox is not supported"

### DIFF
--- a/docker/Emulator_x86
+++ b/docker/Emulator_x86
@@ -171,6 +171,13 @@ ADD src/.fehbg /root/.fehbg
 ADD src/rc.xml /etc/xdg/openbox/rc.xml
 RUN echo /root/.fehbg >> /etc/xdg/openbox/autostart
 
+#======================
+# Workarounds
+#======================
+# Fix emulator from crashing when running as root user.
+# See https://github.com/budtmo/docker-android/issues/223
+ENV QTWEBENGINE_DISABLE_SANDBOX=1
+
 #===============
 # Expose Ports
 #---------------


### PR DESCRIPTION
### Purpose of changes
Fixes https://github.com/budtmo/docker-android/issues/223

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
Ran image. No longer crashes when hitting any of the buttons on the vertical menu bar on the right side of the screen.
No more error `Running as root without --no-sandbox is not supported. See https://crbug.com/638180`