### PR TITLE
Update README to call out that google play store not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,7 @@ SMS Simulation
 
 Google Play Services and Google Play Store
 ------------------------------------------
-
-Docker-Android contains Google Play Service (v12.8.74) and Google Play Store (v11.0.50). Both applications are downloaded from [apklinker](https://www.apklinker.com/), so please be aware of it in case you use private/company account to that applications.
+Not installed at this time.
 
 Jenkins
 -------


### PR DESCRIPTION
### Purpose of changes
Update README to reflect current state of non-installed google play store.  New users incorrectly get the impression that it is currently installed.  See this commit which disabled this feature: https://github.com/budtmo/docker-android/commit/b66c5d122a7404aac67609f2910cc37b2299e4ee

See https://github.com/budtmo/docker-android/issues/130

### Types of changes

Documentation update

### How has this been tested?

None