### PR TITLE
Add Proxy Auth 

### DIFF
--- a/README_CUSTOM_CONFIG.md
+++ b/README_CUSTOM_CONFIG.md
@@ -13,6 +13,15 @@ You can enable proxy inside container and Android emulator by passing following 
 - NO_PROXY="localhost"
 - ENABLE_PROXY_ON_EMULATOR=true
 
+Proxy with authentication
+----
+
+You can set proxy with authentication by passing following environment variable:
+
+- HTTP_PROXY_USER="\<username>"
+- HTTPS_PROXY_PASSWORD="\<password>"
+
+
 Language
 --------
 

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -52,7 +52,16 @@ function enable_proxy_if_needed () {
         adb shell "content update --uri content://telephony/carriers --bind proxy:s:"0.0.0.0" --bind port:s:"0000" --where "mcc=310" --where "mnc=260""
         sleep 5
         adb shell "content update --uri content://telephony/carriers --bind proxy:s:"${p[0]}" --bind port:s:"${p[1]}" --where "mcc=310" --where "mnc=260""
-
+        
+        if [ ! -z "${HTTP_PROXY_USER}" ]; then
+          sleep 2
+          adb shell "content update --uri content://telephony/carriers --bind user:s:"${HTTP_PROXY_USER}" --where "mcc=310" --where "mnc=260""
+        fi
+        if [ ! -z "${HTTP_PROXY_PASSWORD}" ]; then
+          sleep 2
+          adb shell "content update --uri content://telephony/carriers --bind password:s:"${HTTP_PROXY_PASSWORD}" --where "mcc=310" --where "mnc=260""
+        fi
+        
         adb unroot
 
         # Mobile data need to be restarted for Android 10 or higher


### PR DESCRIPTION
Add Variable: 
1. HTTP_PROXY_USER
2. HTTP_PROXY_PASSWORD

### Purpose of changes
I would like to resolve the following issue: 
https://github.com/budtmo/docker-android/issues/235
The current setup script does not support proxy auth.


### Types of changes
_Put an `x` in the boxes that apply_

- [x ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
I dont know how to build the docker file.
However, I test it by running "docker exec -it XXX bash"
and then go run update the "username password" by below command, and the proxy auth work.
```
adb root
adb shell "content update --uri content://telephony/carriers --bind user:s:"XXX" --bind password:s:"XXX" --where "mcc=310" --where "mnc=260""
adb unroot
```
