### PR TITLE
Feature: Support customised Selenium Proxy Class when use Appium

### DIFF
--- a/README_APPIUM_AND_SELENIUM.md
+++ b/README_APPIUM_AND_SELENIUM.md
@@ -25,6 +25,7 @@ It is also possible to connect appium server that run inside docker-android with
 - SELENIUM_HOST="\<host\_ip\_address>"
 - SELENIUM_PORT=\<port\_number>
 - SELENIUM_TIMEOUT=\<timeout\_in\_seconds>
+- SELENIUM_PROXY_CLASS=\<selenium\_proxy\_class\_name>
 
 To run tests for mobile browser, following parameter can be passed:
 

--- a/src/app.py
+++ b/src/app.py
@@ -149,9 +149,10 @@ def appium_run(avd_name: str):
             selenium_host = os.getenv('SELENIUM_HOST', '172.17.0.1')
             selenium_port = int(os.getenv('SELENIUM_PORT', 4444))
             selenium_timeout = int(os.getenv('SELENIUM_TIMEOUT', 30))
+            selenium_proxy_class = int(os.getenv('SELENIUM_PROXY_CLASS', 'org.openqa.grid.selenium.proxy.DefaultRemoteProxy'))
             browser_name = default_web_browser if mobile_web_test else 'android'
             create_node_config(avd_name, browser_name, appium_host, appium_port, selenium_host, selenium_port,
-                               selenium_timeout)
+                               selenium_timeout, selenium_proxy_class)
             cmd += ' --nodeconfig {file}'.format(file=CONFIG_FILE)
         except ValueError as v_err:
             logger.error(v_err)
@@ -160,7 +161,7 @@ def appium_run(avd_name: str):
 
 
 def create_node_config(avd_name: str, browser_name: str, appium_host: str, appium_port: int, selenium_host: str,
-                       selenium_port: int, selenium_timeout: int):
+                       selenium_port: int, selenium_timeout: int, selenium_proxy_class: str):
     """
     Create custom node config file in json format to be able to connect with selenium server.
 
@@ -170,6 +171,7 @@ def create_node_config(avd_name: str, browser_name: str, appium_host: str, appiu
     :param selenium_host: Host where selenium server is running
     :param selenium_port: Port number where selenium server is running
     :param selenium_timeout: Selenium session timeout in seconds
+    :param selenium_proxy_class: Selenium Proxy class created in Selenium hub
     """
     config = {
         'capabilities': [
@@ -185,7 +187,7 @@ def create_node_config(avd_name: str, browser_name: str, appium_host: str, appiu
         'configuration': {
             'cleanUpCycle': 2000,
             'timeout': selenium_timeout,
-            'proxy': 'org.openqa.grid.selenium.proxy.DefaultRemoteProxy',
+            'proxy': selenium_proxy_class,
             'url': 'http://{host}:{port}/wd/hub'.format(host=appium_host, port=appium_port),
             'host': appium_host,
             'port': appium_port,

--- a/src/app.py
+++ b/src/app.py
@@ -149,7 +149,7 @@ def appium_run(avd_name: str):
             selenium_host = os.getenv('SELENIUM_HOST', '172.17.0.1')
             selenium_port = int(os.getenv('SELENIUM_PORT', 4444))
             selenium_timeout = int(os.getenv('SELENIUM_TIMEOUT', 30))
-            selenium_proxy_class = int(os.getenv('SELENIUM_PROXY_CLASS', 'org.openqa.grid.selenium.proxy.DefaultRemoteProxy'))
+            selenium_proxy_class = os.getenv('SELENIUM_PROXY_CLASS', 'org.openqa.grid.selenium.proxy.DefaultRemoteProxy')
             browser_name = default_web_browser if mobile_web_test else 'android'
             create_node_config(avd_name, browser_name, appium_host, appium_port, selenium_host, selenium_port,
                                selenium_timeout, selenium_proxy_class)

--- a/src/tests/unit/test_appium.py
+++ b/src/tests/unit/test_appium.py
@@ -58,7 +58,8 @@ class TestAppium(TestCase):
     def test_config_creation(self):
         from src import CONFIG_FILE
         self.assertFalse(os.path.exists(CONFIG_FILE))
-        app.create_node_config('test', 'android', '127.0.0.1', 4723, '127.0.0.1', 4444, 30)
+        app.create_node_config('test', 'android', '127.0.0.1', 4723, '127.0.0.1', 4444, 30,
+                               'org.openqa.grid.selenium.proxy.DefaultRemoteProxy')
         self.assertTrue(os.path.exists(CONFIG_FILE))
         os.remove(CONFIG_FILE)
 


### PR DESCRIPTION
### Purpose of changes
When I connect Appium to Selenium Hub,  I want to specify different Selenium Proxy Class.

### Types of changes
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
Unit test