### PR TITLE
Fix an issue when attempting to detect an existing AVD image

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -56,7 +56,7 @@ def is_initialized(device_name) -> bool:
     if os.path.exists(config_path):
         logger.info('Found existing config file at {}.'.format(config_path))
         with open(config_path, 'r') as f:
-            if any('hw.device.name={}'.format(device_name) in line for line in f):
+            if any('hw.device.name = {}'.format(device_name) in line for line in f):
                 logger.info('Existing config file references {}. Assuming device was previously initialized.'.format(device_name))
                 return True
             else:


### PR DESCRIPTION
### Purpose of changes
This fixes an issue when detecting existing AVD images on startup.  Fixes #286.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
This has been tested in a live environment and has been shown to work.
