### PR TITLE
Check correctly if device exists

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import re
 import subprocess
 import uuid
 
@@ -56,7 +57,7 @@ def is_initialized(device_name) -> bool:
     if os.path.exists(config_path):
         logger.info('Found existing config file at {}.'.format(config_path))
         with open(config_path, 'r') as f:
-            if any('hw.device.name = {}'.format(device_name) in line for line in f):
+            if any(re.match(r'hw\.device\.name ?= ?{}'.format(device_name), line) for line in f):
                 logger.info('Existing config file references {}. Assuming device was previously initialized.'.format(device_name))
                 return True
             else:

--- a/src/app.py
+++ b/src/app.py
@@ -56,7 +56,7 @@ def is_initialized(device_name) -> bool:
     if os.path.exists(config_path):
         logger.info('Found existing config file at {}.'.format(config_path))
         with open(config_path, 'r') as f:
-            if any('hw.device.name={}'.format(device_name) in line for line in f):
+            if any('hw.device.name = {}'.format(device_name) in line for line in f):
                 logger.info('Existing config file references {}. Assuming device was previously initialized.'.format(device_name))
                 return True
             else:


### PR DESCRIPTION
config.ini has spaces around the equals sign

### Purpose of changes

When restarting an emulated device, the is_initialized function checks if it exists by reading the emulator's config.ini file. The check didn't take into account whitespaces. This is now fixed.

<!-- Please describe why this change is required / What problem you want to solve. -->

### Types of changes
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

Tested on a emulator kill / restart scenario, verifying if new devices where initialized or previous ones restarted.
