### PR TITLE
Support Android 12 (API 31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ List of Docker images
 |Linux|9.0|28|chrome|66.0|2.40|budtmo/docker-android-x86-9.0|[![](https://images.microbadger.com/badges/image/budtmo/docker-android-x86-9.0.svg)](https://microbadger.com/images/budtmo/docker-android-x86-9.0 "Get your own image badge on microbadger.com")|
 |Linux|10.0|29|chrome|74.0|74.0.3729.6|budtmo/docker-android-x86-10.0|[![](https://images.microbadger.com/badges/image/budtmo/docker-android-x86-10.0.svg)](https://microbadger.com/images/budtmo/docker-android-x86-10.0 "Get your own image badge on microbadger.com")|
 |Linux|11.0|30|chrome|83.0|83.0.4103.39|budtmo/docker-android-x86-11.0|[![](https://images.microbadger.com/badges/image/budtmo/docker-android-x86-11.0.svg)](https://microbadger.com/images/budtmo/docker-android-x86-11.0 "Get your own image badge on microbadger.com")|
+|Linux|12.0|31|chrome|93.0|93.0.4577.15|budtmo/docker-android-x86-12.0|[![](https://images.microbadger.com/badges/image/budtmo/docker-android-x86-12.0.svg)](https://microbadger.com/images/budtmo/docker-android-x86-12.0 "Get your own image badge on microbadger.com")|
 |All |-|-|-|-|-|budtmo/docker-android-real-device|[![](https://images.microbadger.com/badges/image/budtmo/docker-android-real-device.svg)](https://microbadger.com/images/budtmo/docker-android-real-device "Get your own image badge on microbadger.com")|
 |All|All|All|All|All|All|budtmo/docker-android-genymotion|[![](https://images.microbadger.com/badges/image/budtmo/docker-android-genymotion.svg)](https://microbadger.com/images/budtmo/docker-android-genymotion "Get your own image badge on microbadger.com")|
 
@@ -115,7 +116,7 @@ Quick Start
 Custom configurations
 ---------------------
 
-[This document](README_CUSTOM_CONFIG.md) contains custom configurations of Docker-Android that you might need, e.g. Proxy, Changing language on fly, etc. 
+[This document](README_CUSTOM_CONFIG.md) contains custom configurations of Docker-Android that you might need, e.g. Proxy, Changing language on fly, etc.
 
 Build Android project
 ---------------------
@@ -133,31 +134,31 @@ Docker-Android can be used for building Android project and executing its unit t
     ```bash
     docker run -it --rm -v $PWD/testing-samples/ui/espresso/BasicSample:/tmp -w /tmp budtmo/docker-android-x86-8.1 /tmp/gradlew build
     ```
-    
+
 Control Android connected to host (Emulator or Real Device)
 -----------------------------------------------------------
-1. Create a docker container with this command 
+1. Create a docker container with this command
 
 	```
 	$ docker run --privileged -d -p 6080:6080 -p 5554:5554 -p 5555:5555 -p 4723:4723 --name android-container-appium budtmo/docker-android-real-device
 	```
-	
+
 2. Open noVNC [http://localhost:6080](http://localhost:6080)
 
 3. Open terminal by clicking right on **noVNC** window >> **Terminal emulator**
 
-4. To connect to host's adb (make sure your host have adb and connected to the device.) 
+4. To connect to host's adb (make sure your host have adb and connected to the device.)
 
 	```
 	$ adb -H host.docker.internal devices
 	```
-	
+
 	To specify port, just add `-P port_number`
 
 	```
 	$ adb -H host.docker.internal -P 5037 devices
 	```
-	
+
 5. Now your container can access your host devices. But, you need to add `remoteAdbHost` and `adbPort` desired capabilities to make **Appium** can recognise those devices.  
 
 

--- a/release.sh
+++ b/release.sh
@@ -143,6 +143,8 @@ function build() {
     FILE_NAME=docker/Emulator_x86
 
     for v in "${versions[@]}"; do
+        level=${list_of_levels[$v]}
+
         # Find image type and default web browser
         if [ "$v" == "5.0.1" ] || [ "$v" == "5.1.1" ]; then
             IMG_TYPE=default
@@ -158,12 +160,12 @@ function build() {
             #adb root cannot be run in IMG_TYPE=google_apis_playstore
             IMG_TYPE=google_apis
             BROWSER=chrome
-            if [ "$v" == "9.0" ] || [ "$v" == "12.0" ]; then
+            # Google dropped 32-bit support at Android 12
+            if [ "$v" == "9.0" ] || [ $level >= 31 ]; then
                 processor=x86_64
             fi
         fi
         echo "[BUILD] IMAGE TYPE: $IMG_TYPE"
-        level=${list_of_levels[$v]}
         echo "[BUILD] API Level: $level"
         sys_img=$processor
         echo "[BUILD] System Image: $sys_img"

--- a/release.sh
+++ b/release.sh
@@ -10,7 +10,7 @@ else
 fi
 
 if [ -z "$2" ]; then
-    read -p "Android version (5.0.1|5.1.1|6.0|7.0|7.1.1|8.0|8.1|9.0|10.0|11.0|all): " ANDROID_VERSION
+    read -p "Android version (5.0.1|5.1.1|6.0|7.0|7.1.1|8.0|8.1|9.0|10.0|11.0|12.0|all): " ANDROID_VERSION
 else
     ANDROID_VERSION=$2
 fi
@@ -32,6 +32,7 @@ declare -A list_of_levels=(
         [9.0]=28
         [10.0]=29
         [11.0]=30
+        [12.0]=31
 )
 
 # The version of the Chrome browser installed on the Android emulator needs to be known beforehand
@@ -47,6 +48,7 @@ declare -A chromedriver_versions=(
         [9.0]="2.40"
         [10.0]="74.0.3729.6"
         [11.0]="83.0.4103.39"
+        [12.0]="93.0.4577.15"
 )
 
 function get_android_versions() {
@@ -66,7 +68,7 @@ function get_android_versions() {
 
     # If version cannot be found in the list
     if [ -z "$versions" ]; then
-        echo "Android version \"$ANDROID_VERSION\" is not found in the list or not supported! Support only version 5.0.1, 5.1.1, 6.0, 7.0, 7.1.1, 8.0, 8.1"
+        echo "Android version \"$ANDROID_VERSION\" is not found in the list or not supported! Support only version 5.0.1, 5.1.1, 6.0, 7.0, 7.1.1, 8.0, 8.1, 9.0, 10.0, 11.0, 12.0"
         exit 1
     fi
 
@@ -151,9 +153,9 @@ function build() {
             BROWSER=browser
         elif [ "$v" == "" ]; then
             IMG_TYPE=google_apis
-            BROWSER=chrome            
+            BROWSER=chrome
         else
-            #adb root cannot be run in IMG_TYPE=google_apis_playstore 
+            #adb root cannot be run in IMG_TYPE=google_apis_playstore
             IMG_TYPE=google_apis
             BROWSER=chrome
             if [ "$v" == "9.0" ]; then

--- a/release.sh
+++ b/release.sh
@@ -158,7 +158,7 @@ function build() {
             #adb root cannot be run in IMG_TYPE=google_apis_playstore
             IMG_TYPE=google_apis
             BROWSER=chrome
-            if [ "$v" == "9.0" ]; then
+            if [ "$v" == "9.0" ] || [ "$v" == "12.0" ]; then
                 processor=x86_64
             fi
         fi


### PR DESCRIPTION
### Purpose of changes
<!-- Please describe why this change is required / What problem you want to solve. -->
@budtmo adding support for Android 12

https://developer.android.com/about/versions/12/get
> Note that 32-bit Android emulator system images are not supported in Android 12

### Types of changes
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Built and ran the image. Ran the unit tests. I also installed the application we use for testing

```
redacted:~/docker-android$ ./release.sh test 12.0 2.0.0
Android versions: 12.0
----UNIT TESTS----
test_invalid_bool (src.tests.unit.test_app.TestApp) ... ok
test_invalid_env (src.tests.unit.test_app.TestApp) ... ok
test_invalid_format (src.tests.unit.test_app.TestApp) ... ok
test_it_doesnt_prepare_avd_if_config_exists (src.tests.unit.test_app.TestApp) ... ok
test_it_prepares_avd_if_config_is_for_another_device (src.tests.unit.test_app.TestApp) ... ok
test_it_prepares_avd_on_first_run (src.tests.unit.test_app.TestApp) ... ok
test_run_with_appium (src.tests.unit.test_app.TestApp) ... ok
test_run_with_appium_and_relaxed_security (src.tests.unit.test_app.TestApp) ... ok
test_run_without_appium (src.tests.unit.test_app.TestApp) ... ok
test_symlink (src.tests.unit.test_app.TestApp) ... ok
test_symlink_already_exist (src.tests.unit.test_app.TestApp) ... ok
test_valid_bool (src.tests.unit.test_app.TestApp) ... ok
test_valid_env (src.tests.unit.test_app.TestApp) ... ok
test_chrome_driver (src.tests.unit.test_appium.TestAppium) ... ok
test_config_creation (src.tests.unit.test_appium.TestAppium) ... ok
test_invalid_integer (src.tests.unit.test_appium.TestAppium) ... ok
test_with_selenium_grid (src.tests.unit.test_appium.TestAppium) ... ok
test_without_selenium_grid (src.tests.unit.test_appium.TestAppium) ... ok
test_nexus_avd_as_default (src.tests.unit.test_avd.TestAvd) ... ok
test_samsung_avd (src.tests.unit.test_avd.TestAvd) ... ok

----------------------------------------------------------------------
XML: /home/linux/docker-android/xunit.xml
Name         Stmts   Miss  Cover
--------------------------------
src.py           6      0   100%
src/app.py     147     45    69%
src/log.py       5      0   100%
--------------------------------
TOTAL          158     45    72%
----------------------------------------------------------------------
Ran 20 tests in 0.038s
```