### PR TITLE
Android 11 build issue with 32-bit image

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -153,8 +153,9 @@ function build() {
             #adb root cannot be run in IMG_TYPE=google_apis_playstore
             IMG_TYPE=google_apis
             BROWSER=chrome
-            # Google dropped 32-bit support at Android 12
-            if [ "$v" == "9.0" ] || [ $level -ge 31 ]; then
+            # Android 9 & Android 11 had build issues that requires 64-bit
+            # Android 12+ Google dropped 32-bit support
+            if [ "$v" == "9.0" ] || [ $level -ge 30 ]; then
                 processor=x86_64
             fi
         fi


### PR DESCRIPTION
### Purpose of changes
<!-- Please describe why this change is required / What problem you want to solve. -->
This changes the system image from x86 to x86_64 for Android 11. For whatever reason the Android 11 image built using x86 was resulting in an AVD that was missing Chrome and other applications (see `Android 11.0 (x86)` in images below). Changing to x86_64 resolves the issue

I debated changing the script to also tag the image based on system image `budtmo/docker-android-x86-11.0` --> `budtmo/docker-android-x86_64-11.0` but decided against it to keep the changes as minimal as possible

| Android 10.0 (x86) | Android 11.0 (x86) | Android 11.0 (x86_64) | Android 12.0 (x86_64) |
| ----------- | ----------- |  ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/10168933/140409024-2734c481-060a-495f-b169-e67e8946bef2.png)  | ![image](https://user-images.githubusercontent.com/10168933/140407634-ad92c1b4-2c36-4322-8262-cdb7e1694eb9.png) | ![image](https://user-images.githubusercontent.com/10168933/140407814-1ec41f82-2299-4ae5-82b4-8de3a65d8956.png) | ![image](https://user-images.githubusercontent.com/10168933/140412168-b37ee9b8-2be8-4c54-b975-0624843b1f5c.png) |


### Types of changes
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
I ran unit tests and deployed to our our production environment for Android testing. These change resolved issues we were seeing with the current image