### PR TITLE
Fixing 'System UI not responding'  popup message appearing on newest android versions

### DIFF
--- a/src/utils.sh
+++ b/src/utils.sh
@@ -77,16 +77,6 @@ function enable_proxy_if_needed () {
   fi
 }
 
-function change_emulator_ram_size() {
-  echo '-------------------------------------------------'
-  echo 'Changing emulator ram size for better performance'
-  echo '-------------------------------------------------'
-  sed '/^hw.ramSize /s/=.*$/= 4096/' /root/android_emulator/hardware-qemu.ini
-  echo '-------------------------------------------------'
-  echo 'Emulator ram size changed to 4096'
-  echo '-------------------------------------------------'
-}
-
 function check_emulator_popups() {
   echo "Waiting for device..."
   wait_emulator_to_be_ready
@@ -114,7 +104,6 @@ function check_emulator_popups() {
       ;;
       *"Not Responding: com.android.systemui"*)
         echo "Dismiss System UI isn't responding alert"
-        change_emulator_ram_size
         adb shell su root 'kill $(pidof com.android.systemui)'
         first_launcher=1
       ;;

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -78,73 +78,73 @@ function enable_proxy_if_needed () {
 }
 
 function change_emulator_ram_size() {
-    echo '-------------------------------------------------'
-    echo 'Changing emulator ram size for better performance'
-    echo '-------------------------------------------------'
-    sed '/^hw.ramSize /s/=.*$/= 4096/' /root/android_emulator/hardware-qemu.ini
-    echo '-------------------------------------------------'
-    echo 'Emulator ram size changed to 4096'
-    echo '-------------------------------------------------'
+  echo '-------------------------------------------------'
+  echo 'Changing emulator ram size for better performance'
+  echo '-------------------------------------------------'
+  sed '/^hw.ramSize /s/=.*$/= 4096/' /root/android_emulator/hardware-qemu.ini
+  echo '-------------------------------------------------'
+  echo 'Emulator ram size changed to 4096'
+  echo '-------------------------------------------------'
 }
 
 function check_emulator_popups() {
-        echo "Waiting for device..."
-        wait_emulator_to_be_ready
-        $ANDROID_HOME/platform-tools/adb wait-for-device shell true
+  echo "Waiting for device..."
+  wait_emulator_to_be_ready
+  $ANDROID_HOME/platform-tools/adb wait-for-device shell true
 
-        EMU_BOOTED=0
-        n=0
+  EMU_BOOTED=0
+  n=0
+  first_launcher=1
+  echo 1 > /tmp/failed
+  while [[ $EMU_BOOTED = 0 ]];do
+      echo "Test for current focus"
+      CURRENT_FOCUS=`$ANDROID_HOME/platform-tools/adb shell dumpsys window 2>/dev/null | grep -i mCurrentFocus`
+      echo "Current focus: ${CURRENT_FOCUS}"
+      case $CURRENT_FOCUS in
+        *"Launcher"*)
+        if [[ $first_launcher == 1 ]]; then
+          echo "Launcher seems to be ready, wait 10 sec for another popup..."
+          sleep 10
+          first_launcher=0
+        else
+          echo "Launcher is ready, Android boot completed"
+          EMU_BOOTED=1
+          rm /tmp/failed
+        fi
+      ;;
+      *"Not Responding: com.android.systemui"*)
+        echo "Dismiss System UI isn't responding alert"
+        change_emulator_ram_size
+        adb shell su root 'kill $(pidof com.android.systemui)'
         first_launcher=1
-        echo 1 > /tmp/failed
-        while [[ $EMU_BOOTED = 0 ]];do
-            echo "Test for current focus"
-            CURRENT_FOCUS=`$ANDROID_HOME/platform-tools/adb shell dumpsys window 2>/dev/null | grep -i mCurrentFocus`
-            echo "Current focus: ${CURRENT_FOCUS}"
-            case $CURRENT_FOCUS in
-            *"Launcher"*)
-              if [[ $first_launcher == 1 ]]; then
-                echo "Launcher seems to be ready, wait 10 sec for another popup..."
-                sleep 10
-                first_launcher=0
-              else
-                echo "Launcher is ready, Android boot completed"
-                EMU_BOOTED=1
-                rm /tmp/failed
-              fi
-            ;;
-            *"Not Responding: com.android.systemui"*)
-              echo "Dismiss System UI isn't responding alert"
-              change_emulator_ram_size
-              adb shell su root 'kill $(pidof com.android.systemui)'
-              first_launcher=1
-            ;;
-            *"Not Responding: com.google.android.gms"*)
-              echo "Dismiss GMS isn't responding alert"
-              adb shell input keyevent KEYCODE_ENTER
-              first_launcher=1
-            ;;
-            *"Not Responding: system"*)
-              echo "Dismiss Process system isn't responding alert"
-              adb shell input keyevent KEYCODE_ENTER
-              first_launcher=1
-            ;;
-            *"ConversationListActivity"*)
-              echo "Close Messaging app"
-              adb shell input keyevent KEYCODE_ENTER
-              first_launcher=1
-            ;;
-            *)
-              n=$((n + 1))
-              echo "Waiting Android to boot 10 sec ($n)..."
-              sleep 10
-              if [ $n -gt 60 ]; then
-                  echo "Android Emulator does not start in 10 minutes"
-                  exit 2
-              fi
-            ;;
-            esac
-        done
-        echo "Android Emulator started."
+      ;;
+      *"Not Responding: com.google.android.gms"*)
+        echo "Dismiss GMS isn't responding alert"
+        adb shell input keyevent KEYCODE_ENTER
+        first_launcher=1
+      ;;
+      *"Not Responding: system"*)
+        echo "Dismiss Process system isn't responding alert"
+        adb shell input keyevent KEYCODE_ENTER
+        first_launcher=1
+      ;;
+      *"ConversationListActivity"*)
+        echo "Close Messaging app"
+        adb shell input keyevent KEYCODE_ENTER
+        first_launcher=1
+      ;;
+      *)
+        n=$((n + 1))
+        echo "Waiting Android to boot 10 sec ($n)..."
+        sleep 10
+        if [ $n -gt 60 ]; then
+            echo "Android Emulator does not start in 10 minutes"
+            exit 2
+        fi
+      ;;
+      esac
+  done
+  echo "Android Emulator started."
 }
 
 change_language_if_needed

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -10,7 +10,7 @@ function wait_emulator_to_be_ready () {
       boot_completed=true
     else
       sleep 1
-    fi      
+    fi
   done
 }
 
@@ -52,7 +52,7 @@ function enable_proxy_if_needed () {
         adb shell "content update --uri content://telephony/carriers --bind proxy:s:"0.0.0.0" --bind port:s:"0000" --where "mcc=310" --where "mnc=260""
         sleep 5
         adb shell "content update --uri content://telephony/carriers --bind proxy:s:"${p[0]}" --bind port:s:"${p[1]}" --where "mcc=310" --where "mnc=260""
-        
+
         if [ ! -z "${HTTP_PROXY_USER}" ]; then
           sleep 2
           adb shell "content update --uri content://telephony/carriers --bind user:s:"${HTTP_PROXY_USER}" --where "mcc=310" --where "mnc=260""
@@ -61,7 +61,7 @@ function enable_proxy_if_needed () {
           sleep 2
           adb shell "content update --uri content://telephony/carriers --bind password:s:"${HTTP_PROXY_PASSWORD}" --where "mcc=310" --where "mnc=260""
         fi
-        
+
         adb unroot
 
         # Mobile data need to be restarted for Android 10 or higher
@@ -77,8 +77,80 @@ function enable_proxy_if_needed () {
   fi
 }
 
+function change_emulator_ram_size() {
+    echo '-------------------------------------------------'
+    echo 'Changing emulator ram size for better performance'
+    echo '-------------------------------------------------'
+    sed '/^hw.ramSize /s/=.*$/= 4096/' /root/android_emulator/hardware-qemu.ini
+    echo '-------------------------------------------------'
+    echo 'Emulator ram size changed to 4096'
+    echo '-------------------------------------------------'
+}
+
+function check_emulator_popups() {
+        echo "Waiting for device..."
+        wait_emulator_to_be_ready
+        $ANDROID_HOME/platform-tools/adb wait-for-device shell true
+
+        EMU_BOOTED=0
+        n=0
+        first_launcher=1
+        echo 1 > /tmp/failed
+        while [[ $EMU_BOOTED = 0 ]];do
+            echo "Test for current focus"
+            CURRENT_FOCUS=`$ANDROID_HOME/platform-tools/adb shell dumpsys window 2>/dev/null | grep -i mCurrentFocus`
+            echo "Current focus: ${CURRENT_FOCUS}"
+            case $CURRENT_FOCUS in
+            *"Launcher"*)
+              if [[ $first_launcher == 1 ]]; then
+                echo "Launcher seems to be ready, wait 10 sec for another popup..."
+                sleep 10
+                first_launcher=0
+              else
+                echo "Launcher is ready, Android boot completed"
+                EMU_BOOTED=1
+                rm /tmp/failed
+              fi
+            ;;
+            *"Not Responding: com.android.systemui"*)
+              echo "Dismiss System UI isn't responding alert"
+              change_emulator_ram_size
+              adb shell su root 'kill $(pidof com.android.systemui)'
+              first_launcher=1
+            ;;
+            *"Not Responding: com.google.android.gms"*)
+              echo "Dismiss GMS isn't responding alert"
+              adb shell input keyevent KEYCODE_ENTER
+              first_launcher=1
+            ;;
+            *"Not Responding: system"*)
+              echo "Dismiss Process system isn't responding alert"
+              adb shell input keyevent KEYCODE_ENTER
+              first_launcher=1
+            ;;
+            *"ConversationListActivity"*)
+              echo "Close Messaging app"
+              adb shell input keyevent KEYCODE_ENTER
+              first_launcher=1
+            ;;
+            *)
+              n=$((n + 1))
+              echo "Waiting Android to boot 10 sec ($n)..."
+              sleep 10
+              if [ $n -gt 60 ]; then
+                  echo "Android Emulator does not start in 10 minutes"
+                  exit 2
+              fi
+            ;;
+            esac
+        done
+        echo "Android Emulator started."
+}
+
 change_language_if_needed
 sleep 1
 enable_proxy_if_needed
 sleep 1
 install_google_play
+sleep 1
+check_emulator_popups

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -64,7 +64,7 @@ stderr_logfile=%(ENV_LOG_PATH)s/video-recording.stderr.log
 priority=4
 
 [program:adb-utils]
-command=./src/utils.sh
+command=bash ./src/utils.sh
 autorestart=false
 stdout_logfile=%(ENV_LOG_PATH)s/adb-utils.stdout.log
 stderr_logfile=%(ENV_LOG_PATH)s/adb-utils.stderr.log


### PR DESCRIPTION
### Purpose of changes
On some emulators devices with android version such as 9.0, 10.0, 11.0 and 12.0, when docker container is starting up and the emulator is getting started, a popups error message is shown up that says: **`System UI not responding`**, causing that the emulator can’t be continued to use. This problem can be solved by increasing the ram size of the emulator when it gets started. However, not all the emulators are having this problem, so this solution address two things: 
After booting, the script checks
1) if the emulator shows popup message **"System UI not responding"**: it closes the popup by killing the process, increase the ram size, then it checks that no new popup windows is shown up again and it waits until the screen is fully clean by checking the **Launcher process** which indicates that emulator is displaying the home screen and is ready.  
2)  if the emulator doesn't show popup message **System UI not responding**, it waits until the screen is fully clean by checking the **Launcher process** which indicates that emulator is displaying the home screen and is ready. 

Currently, there are a list of open issues that are meant to be close with this solution:
[system UI is not responding when starts the container](https://github.com/budtmo/docker-android/issues/316)
[system UI isn't responding after boot on VM](https://github.com/budtmo/docker-android/issues/109)

### Types of changes
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
This was tested on a Linux VM by spinning up different combinations of android versions and device models as following:

**Samsung Galaxy S7 Edge - Android 9.0**
Before
<img width="883" alt="Galaxy S7 Edge" src="https://user-images.githubusercontent.com/33426940/167076120-d262481e-678c-4a61-9271-22db59aa49f5.png">

After
<img width="871" alt="Galaxy S7 Edge" src="https://user-images.githubusercontent.com/33426940/167076153-279e6633-ab12-4a57-9826-b82235184b2d.png">

**Nexus 5- Android 9.0**
Before
<img width="864" alt="performance is not quite good" src="https://user-images.githubusercontent.com/33426940/167076230-acea0e21-45c6-4c8a-bba7-daff3c31de7b.png">

After
<img width="870" alt="Never show this again" src="https://user-images.githubusercontent.com/33426940/167076263-b184fc8b-71f8-4dba-b1d3-729998ecb5c5.png">

**Samsung Galaxy S10- Android 10.0**
Before
<img width="879" alt="Emulator is running using nested virtualization" src="https://user-images.githubusercontent.com/33426940/167076352-4d0f4813-4f70-4c7e-bf79-4228bc403df5.png">

After
<img width="871" alt="SAMSUNG" src="https://user-images.githubusercontent.com/33426940/167076385-329cf2e0-9faf-4565-a612-8940a3d5c2c8.png">

**Samsung Galaxy S8- Android 12.0**
Before
<img width="867" alt="performance is not quite good" src="https://user-images.githubusercontent.com/33426940/167076453-8e19b0fa-3fcd-47b7-8e78-41f093e2c575.png">

After
<img width="876" alt="Never show this again" src="https://user-images.githubusercontent.com/33426940/167076486-822ac39f-261a-4f62-871b-f6e45fd95c33.png">




