### PR TITLE
Added custom RAM size via environment variable

### DIFF
--- a/README_CUSTOM_CONFIG.md
+++ b/README_CUSTOM_CONFIG.md
@@ -39,6 +39,15 @@ The size of the data partition can be set by passing the following environment v
 
 The value can be specified in the same format that is used by the emulator config file (`disk.dataPartition.size`), e.g. `800m`.
 
+RAM memory
+-------------------
+
+The size of the RAM memory of the emulated device can be set by passing the following environment variable:
+
+- RAMSIZE="\<size>"
+
+The value is specified in megabytes (as in the emulator config file's `hw.ramSize` entry), and is 2048 by default.
+
 Camera
 ------
 

--- a/docker/Emulator_x86
+++ b/docker/Emulator_x86
@@ -89,8 +89,8 @@ RUN  wget -nv -O noVNC.zip "https://github.com/kanaka/noVNC/archive/${NOVNC_SHA}
 #======================
 # Install SDK packages
 #======================
-ARG ANDROID_VERSION=5.0.1
-ARG API_LEVEL=21
+ARG ANDROID_VERSION=9
+ARG API_LEVEL=29
 ARG PROCESSOR=x86
 ARG SYS_IMG=x86
 ARG IMG_TYPE=google_apis

--- a/src/app.py
+++ b/src/app.py
@@ -83,7 +83,7 @@ logger.info('Android version: {version} \n'
                                             img=SYS_IMG, img_type=IMG_TYPE))
 
 
-def prepare_avd(device: str, avd_name: str, dp_size: str):
+def prepare_avd(device: str, avd_name: str, dp_size: str, ram_size: str):
     """
     Create and run android virtual device.
 
@@ -117,6 +117,7 @@ def prepare_avd(device: str, avd_name: str, dp_size: str):
     with open(config_path, 'a') as file:
         file.write('skin.path={sp}'.format(sp=skin_path))
         file.write('\ndisk.dataPartition.size={dp}'.format(dp=dp_size))
+        file.write('\nhw.ramSize={ram}'.format(ram=ram_size))
 
     logger.info('Skin was added in config.ini')
 
@@ -217,10 +218,11 @@ def run():
     is_first_run = not is_initialized(device)
 
     dp_size = os.getenv('DATAPARTITION', '550m')
+    ram_size = os.getenv('RAMSIZE', '2048')
 
     if is_first_run:
         logger.info('Preparing emulator...')
-        prepare_avd(device, avd_name, dp_size)
+        prepare_avd(device, avd_name, dp_size, ram_size)
 
     logger.info('Run emulator...')
 


### PR DESCRIPTION
### Purpose of changes
The current version of Docker-Android has a fixed RAM size. Using this new version, it is possible to set up a custom RAM size for each device.

### Types of changes
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
This feature has been tested by performing research-related tests that execute demanding applications (i.e., Alpine Linux VMs inside the virtual device), and has been checked to work properly.
