### PR TITLE
Fixed docker container stop/start blank background error

### DIFF
--- a/cli/src/device/emulator.py
+++ b/cli/src/device/emulator.py
@@ -134,6 +134,10 @@ class Emulator(Device):
             self.logger.info(f"{self.device_type} is created!")
 
     def change_permission(self) -> None:
+        not_first_run = self.is_initialized()
+        if not_first_run:
+            return
+
         kvm_path = "/dev/kvm"
         if os.path.exists(kvm_path):
             cmds = (f"sudo chown 1300:1301 {kvm_path}",


### PR DESCRIPTION
### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Purpose of changes
When doing docker stop then start, getting blank background instead of emulator and error in logs:
sudo: unknown user: root
sudo: unable to initialize policy plugin
...
subprocess.CalledProcessError: Command 'sudo chown 1300:1301 /dev/kvm' returned non-zero exit status 1.

**Related issues:**
https://github.com/budtmo/docker-android/issues/365
https://github.com/budtmo/docker-android/issues/373