### PR TITLE
Disable the nested virtualization warning by default.

### DIFF
--- a/docker/emulator
+++ b/docker/emulator
@@ -99,6 +99,8 @@ ENV LOG_PATH=${WORK_PATH}/logs \
     WEB_LOG_PORT=9000
 EXPOSE 9000
 RUN mkdir -p ${LOG_PATH}
+RUN mkdir -p "${WORK_PATH}/.config/Android Open Source Project" \
+ && echo "[General]\nshowNestedWarning=false\n" > "${WORK_PATH}/.config/Android Open Source Project/Emulator.conf"
 
 #=========
 # Run App


### PR DESCRIPTION
### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Purpose of changes
<!-- Please describe why this change is required / What problem you want to solve. -->

When run in nested virtualization, a warning dialog shows up saying that the performance may not be good but that's not really helpful and in fully-automated scenarios, it creates unnecessary distraction.

Fixes #281
