### PR TITLE
Fix typo in WSL configuration file name: `wsl2.conf` does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Credit goes to [Guillaume - The Parallel Interface blog](https://www.paralint.co
     sudo usermod -a -G kvm ${USER}
     ```
 
-2. Add necessary flags to `/etc/wsl2.conf` to their respective sections.
+2. Add necessary flags to `/etc/wsl.conf` to their respective sections.
     ```
     [boot]
     command = /bin/bash -c 'chown -v root:kvm /dev/kvm && chmod 660 /dev/kvm'


### PR DESCRIPTION
There is no documentation that file `/etc/wsl2.conf` does exist. According to Microsoft documentation, it is called `/etc/wsl.conf`. 

See https://learn.microsoft.com/en-us/windows/wsl/wsl-config for reference.

### Types of changes
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Purpose of changes
Just a small proposal of a typo I think there is at the `README.md` file.