### PR TITLE
Refactor change_permission method for KVM permission

### DIFF
--- a/cli/src/device/emulator.py
+++ b/cli/src/device/emulator.py
@@ -164,15 +164,14 @@ class Emulator(Device):
 
     def change_permission(self) -> None:
         kvm_path = "/dev/kvm"
-        if os.path.exists(kvm_path):
-            cmds = (f"sudo chown 1300:1301 {kvm_path}",
-                    "sudo sed -i '1d' /etc/passwd")
-            for c in cmds:
-                subprocess.check_call(c, shell=True)
-            self.logger.info("KVM permission is granted!")
-        else:
+        if not os.path.exists(kvm_path):
             raise RuntimeError("/dev/kvm cannot be found!")
-
+        subprocess.check_call(
+            f"sudo chown 1300:1301 {kvm_path}",
+            shell=True
+        )
+        self.logger.info("KVM permission is granted!")
+    
     def deploy(self):
         self.logger.info(f"Deploying the {self.device_type}")
 


### PR DESCRIPTION
### Types of changes

*Put an `x` in the boxes that apply*

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)

### Purpose of changes

<!-- Please describe why this change is required / What problem you want to solve. -->

Fixes https://github.com/budtmo/docker-android/issues/476

The container works correctly when it is started for the first time:

<img width="968" height="736" alt="image" src="https://github.com/user-attachments/assets/dbba7548-5c67-4270-940b-b976d7407091" />

However, after restarting the container, the Android emulator fails to start:

<img width="875" height="383" alt="image" src="https://github.com/user-attachments/assets/4206c978-ecd7-4b78-aa8c-f0e2b114a5e8" />

After the container is restarted, the ownership/group of `/dev/kvm` changes:

```bash
androidusr@379dfd412626:~$ ll /dev/kvm
crw-rw---- 1 0 994 10, 232 Aug 12 20:49 /dev/kvm
```

As a result, `androidusr` no longer has permission to access `/dev/kvm`, preventing QEMU from creating and running the Android emulator.
