### PR TITLE
fix: preserve spaces in emulator arguments

### DIFF
--- a/cli/src/device/emulator.py
+++ b/cli/src/device/emulator.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import shlex
 import subprocess
 import time
 
@@ -182,7 +183,7 @@ class Emulator(Device):
 
         start_cmd = f"{basic_cmd} {basic_args} {wipe_arg} {self.additional_args}"
         self.logger.info(f"Command to run {self.device_type}: '{start_cmd}'")
-        subprocess.Popen(start_cmd.split())
+        subprocess.Popen(shlex.split(start_cmd))
 
     def start(self) -> None:
         super().start()

--- a/cli/src/tests/device/test_emulator.py
+++ b/cli/src/tests/device/test_emulator.py
@@ -63,6 +63,18 @@ class TestEmulator(BaseDeviceTest):
                 self.emu.check_adb_command(
                     self.emu.ReadinessCheck.BOOTED, "mocked_command", "1", 3, 0)
 
+    def test_deploy_preserves_spaces_in_quoted_additional_args(self):
+        self.emu.additional_args = '-turncfg "cat /tmp/turn.cfg"'
+
+        with mock.patch.object(self.emu, "is_initialized", return_value=True), \
+                mock.patch("subprocess.Popen") as popen:
+            self.emu.deploy()
+
+        popen.assert_called_once_with([
+            "emulator", "@my_emu", "-gpu", "swiftshader_indirect", "-accel", "on",
+            "-writable-system", "-verbose", "-turncfg", "cat /tmp/turn.cfg"
+        ])
+
     def test_use_override_config_no_env(self):
         with mock.patch("os.getenv", return_value=None):
             self.emu._use_override_config()


### PR DESCRIPTION
### Types of changes
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Purpose of changes

Fixes #430.

`Emulator.deploy()` used whitespace-only `str.split()` when converting the launch command to an argument list. That breaks quoted values containing spaces, so an input such as `-turncfg "cat /tmp/turn.cfg"` reaches the emulator as two arguments and `/tmp/turn.cfg` is rejected as an unknown flag.

This changes the parser to standard-library `shlex.split()` while continuing to invoke `Popen` with an argument list and `shell=False`. A regression test exercises the real deploy path and verifies that the quoted value remains one argument.

### Regression evidence

- Before the fix, the new targeted test failed because `Popen` received `"cat` and `/tmp/turn.cfg"` as separate values.
- After the fix, the same test passes and receives `cat /tmp/turn.cfg` as one value.

### Verification

- Targeted regression: 1 passed.
- CLI test suite: 24 passed.
- MCP test suite: 13 passed.
- Python 3.9 and 3.14 compile checks passed.
- `git diff --check` passed.

The repository's Docker test wrappers could not run locally because the Docker daemon was not reachable. Their underlying pytest suites were run directly with the pinned requirements on Python 3.14.6, the nearest locally available patch release to the wrappers' configured Python 3.14.7. Analytics was disabled for every test command.

### Scope

- 2 files changed, +14 / -1 lines.
- No dependency or generated-file changes.
